### PR TITLE
Support deep export via optional '--deep' argument

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -54,10 +54,15 @@ import M.B
 Autoexporter will generally behave as you'd expect, but there are a couple
 things to look out for:
 
-- Only immediate children will be re-exported. If you use this in some module
-  `M`, it won't pull in `M.A.B`.
-
 - You cannot selectively include or exclude any modules.
+
+- By default, only immediate children will be re-exported. If you use this in
+  some module `M`, it won't pull in `M.A.B`. If you need deep re-exporting,
+  please pass `--deep` to Autoexporter like this:
+
+```haskell
+{-# OPTIONS_GHC -F -pgmF autoexporter -optF --deep #-}
+```
 
 [Autoexporter]: https://github.com/tfausak/autoexporter
 [Version badge]: https://www.stackage.org/package/autoexporter/badge/nightly?label=version


### PR DESCRIPTION
This closes #5.

The new behavior is optional.  The standard way to use `autoexporter` is via
`{-# OPTIONS_GHC -F -pgmF autoexporter #-}`
and this does shallow re-exporting.

If a user wants deep re-exporting, they can do
`{-# OPTIONS_GHC -F -pgmF autoexporter -optF --deep #-}`.