### PR TITLE
Silence warnings when exporting empty modules

### DIFF
--- a/library/Autoexporter.hs
+++ b/library/Autoexporter.hs
@@ -105,7 +105,8 @@ isHaskellFile x = List.isSuffixOf ".hs" x || List.isSuffixOf ".lhs" x
 renderModule :: String -> [String] -> String
 renderModule name modules =
   unlines'
-    [ unwords ["module", name, "("]
+    [ "{-# OPTIONS_GHC -fno-warn-dodgy-exports -fno-warn-unused-imports #-}"
+    , unwords ["module", name, "("]
     , unlines' (map renderExport modules)
     , ") where"
     , unlines' (map renderImport modules)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: autoexporter
-version: 1.1.14
+version: 1.1.15
 
 category: Utility
 description: Autoexporter automatically re-exports modules.


### PR DESCRIPTION
If a folder contains an module without exports, the auto-generated autoexporter file will currently give warnings.

I'm having this problem because I'm trying to separate orphan instances between "internal" private modules, and then using autoexporter to generate a public module.