### PR TITLE
Run build in Docker container

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -140,7 +140,7 @@
           "uses": "actions/cache@v3",
           "with": {
             "key": "docker-${{ hashFiles('cabal.project.freeze') }}",
-            "path": "${{ steps.haskell.outputs.cabal-store }}",
+            "path": "/root/.cabal/store",
             "restore-keys": "docker-"
           }
         },

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -131,7 +131,7 @@
           "uses": "actions/cache@v3",
           "with": {
             "key": "cabal-packages",
-            "path": "/root/.cabal/packages"
+            "path": "~/.cabal/packages"
           }
         },
         {
@@ -147,21 +147,12 @@
           "uses": "actions/cache@v3",
           "with": {
             "key": "cabal-store-${{ hashFiles('cabal.project.freeze') }}",
-            "path": "/root/.cabal/store",
+            "path": "~/.cabal/store",
             "restore-keys": "cabal-store-"
           }
         },
         {
           "run": "cabal build"
-        },
-        {
-          "run": "ls -A -l /root"
-        },
-        {
-          "run": "ls -A -l /github/home"
-        },
-        {
-          "run": "ls -A -l ~"
         }
       ]
     },

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -128,13 +128,6 @@
           "uses": "actions/checkout@v3"
         },
         {
-          "uses": "actions/cache@v3",
-          "with": {
-            "key": "cabal-packages",
-            "path": "~/.cabal/packages"
-          }
-        },
-        {
           "run": "cabal update"
         },
         {

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -128,6 +128,13 @@
           "uses": "actions/checkout@v3"
         },
         {
+          "uses": "actions/cache@v3",
+          "with": {
+            "key": "cabal-packages",
+            "path": "/root/.cabal/packages"
+          }
+        },
+        {
           "run": "cabal update"
         },
         {
@@ -139,9 +146,9 @@
         {
           "uses": "actions/cache@v3",
           "with": {
-            "key": "docker-${{ hashFiles('cabal.project.freeze') }}",
+            "key": "cabal-store-${{ hashFiles('cabal.project.freeze') }}",
             "path": "/root/.cabal/store",
-            "restore-keys": "docker-"
+            "restore-keys": "cabal-store-"
           }
         },
         {

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -121,7 +121,7 @@
       "container": {
         "image": "public.ecr.aws/acilearning/haskell:9.4.4"
       },
-      "run-on": "ubuntu-22.04",
+      "runs-on": "ubuntu-22.04",
       "steps": [
         {
           "uses": "actions/checkout@v3"

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -119,7 +119,8 @@
     },
     "build-docker": {
       "container": {
-        "image": "public.ecr.aws/acilearning/haskell:9.4.4"
+        "image": "public.ecr.aws/acilearning/haskell:9.4.4",
+        "options": "--user root"
       },
       "runs-on": "ubuntu-22.04",
       "steps": [

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -153,6 +153,12 @@
         },
         {
           "run": "cabal build"
+        },
+        {
+          "run": "ls -A -l /root"
+        },
+        {
+          "run": "ls -l /root/.cabal"
         }
       ]
     },

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -158,7 +158,10 @@
           "run": "ls -A -l /root"
         },
         {
-          "run": "ls -l /root/.cabal"
+          "run": "ls -A -l /github/home"
+        },
+        {
+          "run": "ls -A -l ~"
         }
       ]
     },

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -117,6 +117,37 @@
         }
       }
     },
+    "build-docker": {
+      "container": {
+        "image": "public.ecr.aws/acilearning/haskell:9.4.4"
+      },
+      "run-on": "ubuntu-22.04",
+      "steps": [
+        {
+          "uses": "actions/checkout@v3"
+        },
+        {
+          "run": "cabal update"
+        },
+        {
+          "run": "cabal configure --enable-optimization=2 --flags pedantic --jobs"
+        },
+        {
+          "run": "cabal freeze"
+        },
+        {
+          "uses": "actions/cache@v3",
+          "with": {
+            "key": "docker-${{ hashFiles('cabal.project.freeze') }}",
+            "path": "${{ steps.haskell.outputs.cabal-store }}",
+            "restore-keys": "docker-"
+          }
+        },
+        {
+          "run": "cabal build"
+        }
+      ]
+    },
     "cabal": {
       "name": "Cabal",
       "runs-on": "ubuntu-22.04",


### PR DESCRIPTION
I was curious if I could replace the Ubuntu jobs with ones running in a Docker container. There are a few upsides here:

- Already having the right versions of GHC and Cabal installed. 
- Running CI with the same Docker image that the development container uses. 
- Avoiding some weird (but rare) bugs with GitHub Actions: https://discourse.haskell.org/t/incident-github-actions-ci-failure-ghcup/5761?u=taylorfausak

However there are also some downsides:

- Obviously it only works with Linux. 
- It's probably slower because the Docker image isn't as small as it could be. Currently it's about 561 MB. 
- It doesn't actually test the devcontainer, although maybe it could with https://github.com/marketplace/actions/devcontainers-ci. 